### PR TITLE
Add YearlyCalendar

### DIFF
--- a/front/components/YearlyCalendar.js
+++ b/front/components/YearlyCalendar.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import styles from './YearlyCalendar.module.css'
+import classNames from 'classnames';
+export default function YearlyCalendar() {
+
+	return (
+        <div className={styles.wrapper}>
+            <div className={styles.header}>
+                <h2>2020년 부트캠프</h2>
+                <p>무료 부트캠프 일정을 한 눈에 확인하세요.</p>
+                <ul className={styles.gantt__tags}> 
+                    <li style={{ gridColumn: `0/11`, backgroundColor: `#2ecaac` }}>2기 모집</li>
+                    <li style={{ gridColumn: `11/12`, backgroundColor: `#ff6252` }}>코딩테스트</li>
+                    <li style={{ gridColumn: `126/160`, backgroundColor: `#54c6f9` }}>프리코스</li>
+                </ul>
+            </div>
+            <div className={styles.gantt}>
+                <div className={classNames({[styles.gantt__row]: true, [styles.gantt__row__months]: true})}>
+                        <div className={styles.gantt__row__first}></div>
+                        <span>1월</span><span>2월</span><span>3월</span>
+                        <span>4월</span><span>5월</span><span>6월</span>
+                        <span>7월</span><span>8월</span><span>9월</span>
+                        <span>10월</span><span>11월</span><span>12월</span>
+                </div>
+                <div className={classNames({[styles.gantt__row]: true, [styles.gantt__row__lines]: true})}>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span className="marker"></span><span></span>
+                        <span></span><span></span><span></span>
+                </div>
+                <div className={styles.gantt__row}>
+                    <div className={styles.gantt__row__first}>
+                        SW 마에스트로
+                    </div>
+                    <ul className={styles.gantt__row__bars}>
+                        <li style={{ gridColumn: `1/2`, backgroundColor: `#2ecaac` }}>11기 모집</li>
+                        <li style={{ gridColumn: `2/3`, backgroundColor: `#ff6252` }}>코딩테스트/면접</li>
+                    </ul>
+                    <ul className={styles.gantt__row__bars}></ul>
+                </div>
+                <div className={styles.gantt__row}>
+                    <div className={styles.gantt__row__first}>
+                        42 Seoul
+                    </div>
+                    <ul className={styles.gantt__row__bars}>
+                        <li style={{ gridColumn: `1/13`, backgroundColor: `#2ecaac` }}>1차 온라인테스트 상시모집</li>
+                        <li style={{ gridColumn: `1/2`, backgroundColor: `#54c6f9` }}>1-1차 La Piscine</li>
+                        <li style={{ gridColumn: `5/6`, backgroundColor: `#54c6f9` }}>1-2차 La Piscine</li>
+                        <li style={{ gridColumn: `7/8`, backgroundColor: `#54c6f9` }}>2-1차 La Piscine</li>
+                    </ul>
+                </div>
+                <div className={styles.gantt__row}>
+                    <div className={styles.gantt__row__first}>
+                        SSAFY
+                    </div>
+                    <ul className={styles.gantt__row__bars}>
+                        <li style={{ gridColumn: `5/6`, backgroundColor: `#2ecaac` }}>4기 모집</li>
+                        <li style={{ gridColumn: `6/7`, backgroundColor: `#ff6252` }}>CBT</li>
+                    </ul>
+                </div>
+                <div className={styles.gantt__row}>
+                    <div className={styles.gantt__row__first}>
+                        우아한테크코스
+                    </div>
+                    <ul className={styles.gantt__row__bars}>
+                        <li style={{ gridColumn: `10/11`, backgroundColor: `#2ecaac` }}>2기 모집</li>
+                        <li style={{ gridColumn: `11/12`, backgroundColor: `#ff6252` }}>코딩테스트</li>
+                        <li style={{ gridColumn: `12/13`, backgroundColor: `#54c6f9` }}>프리코스</li>
+                    </ul>
+                </div>
+                <div className={styles.gantt__row}>
+                    <div className={styles.gantt__row__first}>
+                        네이버 부스트캠프
+                    </div>
+                    <ul className={styles.gantt__row__bars}>
+                        <li style={{ gridColumn: `6/7`, backgroundColor: `#2ecaac` }}>모집</li>
+                        <li style={{ gridColumn: `7/8`, backgroundColor: `#ff6252` }}>코딩테스트</li>
+                        <li style={{ gridColumn: `8/9`, backgroundColor: `#54c6f9` }}>부스트캠프 챌린지</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+	);
+  }

--- a/front/components/YearlyCalendar.js
+++ b/front/components/YearlyCalendar.js
@@ -8,12 +8,6 @@ export default function YearlyCalendar() {
             <div className={styles.header}>
                 <h2>2020년 부트캠프</h2>
                 <p>무료 부트캠프 일정을 한 눈에 확인하세요.</p>
-                {/* <ul className={styles.gantt__tags}>
-                        <li style={{  backgroundColor: `#2ecaac` }}>모집</li>
-                        <li style={{  backgroundColor: `lightpink` }}>온라인 코딩테스트</li>
-                        <li style={{  backgroundColor: `#54c6f9` }}>오프라인 코딩테스트</li>
-                        <li style={{  backgroundColor: `orange` }}>면접</li>
-                </ul> */}
             </div>
             <div className={styles.gantt}>
                 <div className={classNames({[styles.gantt__row]: true, [styles.gantt__row__months]: true})}>
@@ -48,7 +42,7 @@ export default function YearlyCalendar() {
                         SW 마에스트로
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `4/8`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `4/8`, backgroundColor: `#4DF0FF`, zIndex: `1` }}>
                             <span className={styles.calendar_entry__date}>1/22 - 3/10</span>
                             <span className={styles.calendar_entry__title}>지원</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
@@ -68,20 +62,20 @@ export default function YearlyCalendar() {
                         42 Seoul
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `1/53`, backgroundColor: `#2ecaac` }}>지원</li>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `3/7`, backgroundColor: `#54c6f9` }}>
+                        <li style={{ gridColumn: `1/53`, backgroundColor: `#4DF0FF` }}>지원</li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `3/7`, backgroundColor: `#5C4DFF` }}>
                             <span className={styles.calendar_entry__date}>1/23 - 2/16</span>
-                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__title}>Piscine</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
                         </li>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `20/24`, backgroundColor: `#54c6f9`, zIndex: `1` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `20/24`, backgroundColor: `#5C4DFF`, zIndex: `1` }}>
                             <span className={styles.calendar_entry__date}>5/29 - 6/25</span>
-                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__title}>Piscine</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
                         </li>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `28/32`, backgroundColor: `#54c6f9` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `28/32`, backgroundColor: `#5C4DFF` }}>
                             <span className={styles.calendar_entry__date}>7/1 - 7/30</span>
-                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__title}>Piscine</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
                         </li>
                     </ul>
@@ -91,7 +85,7 @@ export default function YearlyCalendar() {
                         SSAFY
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `19/22`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `19/22`, backgroundColor: `#4DF0FF`, zIndex: `1` }}>
                             <span className={styles.calendar_entry__date}>5/11 - 5/25</span>
                             <span className={styles.calendar_entry__title}>지원</span>
                             <span className={styles.calendar_entry__details}><a>4기</a></span>
@@ -108,7 +102,7 @@ export default function YearlyCalendar() {
                         우아한테크코스
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `44/47`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `44/47`, backgroundColor: `#4DF0FF`, zIndex: `1` }}>
                             <span className={styles.calendar_entry__date}>5/11 - 5/25</span>
                             <span className={styles.calendar_entry__title}>지원</span>
                             <span className={styles.calendar_entry__details}><a>4기</a></span>
@@ -125,14 +119,19 @@ export default function YearlyCalendar() {
                         네이버 부스트캠프
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `23/27`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `23/27`, backgroundColor: `#4DF0FF`, zIndex: `1` }}>
                             <span className={styles.calendar_entry__date}>5/11 - 5/25</span>
                             <span className={styles.calendar_entry__title}>지원</span>
                             <span className={styles.calendar_entry__details}><a>4기</a></span>
                         </li>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `27/33`, backgroundColor: `#54c6f9` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `27/31`, backgroundColor: `#54c6f9`, }}>
                             <span className={styles.calendar_entry__date}>7/1 - 7/30</span>
                             <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `32/36`, backgroundColor: `#5C4DFF` }}>
+                            <span className={styles.calendar_entry__date}>8/5 - 8/30</span>
+                            <span className={styles.calendar_entry__title}>챌린지</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
                         </li>
                     </ul>

--- a/front/components/YearlyCalendar.js
+++ b/front/components/YearlyCalendar.js
@@ -8,10 +8,11 @@ export default function YearlyCalendar() {
             <div className={styles.header}>
                 <h2>2020년 부트캠프</h2>
                 <p>무료 부트캠프 일정을 한 눈에 확인하세요.</p>
-                <ul className={styles.gantt__tags}> 
-                    <li style={{ gridColumn: `0/11`, backgroundColor: `#2ecaac` }}>2기 모집</li>
-                    <li style={{ gridColumn: `11/12`, backgroundColor: `#ff6252` }}>코딩테스트</li>
-                    <li style={{ gridColumn: `126/160`, backgroundColor: `#54c6f9` }}>프리코스</li>
+                <ul className={styles.gantt__tags}>
+                        <li style={{  backgroundColor: `#2ecaac` }}>모집</li>
+                        <li style={{  backgroundColor: `lightpink` }}>온라인 코딩테스트</li>
+                        <li style={{  backgroundColor: `#54c6f9` }}>오프라인 코딩테스트</li>
+                        <li style={{  backgroundColor: `orange` }}>면접</li>
                 </ul>
             </div>
             <div className={styles.gantt}>
@@ -25,7 +26,21 @@ export default function YearlyCalendar() {
                 <div className={classNames({[styles.gantt__row]: true, [styles.gantt__row__lines]: true})}>
                         <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
-                        <span></span><span className="marker"></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span className={styles.marker}></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
+                        <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
                 </div>
                 <div className={styles.gantt__row}>
@@ -33,8 +48,9 @@ export default function YearlyCalendar() {
                         SW 마에스트로
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `1/2`, backgroundColor: `#2ecaac` }}>11기 모집</li>
-                        <li style={{ gridColumn: `2/3`, backgroundColor: `#ff6252` }}>코딩테스트/면접</li>
+                        <li style={{ gridColumn: `4/8`, backgroundColor: `#2ecaac` }}>모집</li>
+                        <li style={{ gridColumn: `12/13`, backgroundColor: `lightpink` }}></li>
+                        <li style={{ gridColumn: `13/14`, backgroundColor:`orange` }}></li>
                     </ul>
                     <ul className={styles.gantt__row__bars}></ul>
                 </div>
@@ -43,10 +59,10 @@ export default function YearlyCalendar() {
                         42 Seoul
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `1/13`, backgroundColor: `#2ecaac` }}>1차 온라인테스트 상시모집</li>
-                        <li style={{ gridColumn: `1/2`, backgroundColor: `#54c6f9` }}>1-1차 La Piscine</li>
-                        <li style={{ gridColumn: `5/6`, backgroundColor: `#54c6f9` }}>1-2차 La Piscine</li>
-                        <li style={{ gridColumn: `7/8`, backgroundColor: `#54c6f9` }}>2-1차 La Piscine</li>
+                        <li style={{ gridColumn: `1/53`, backgroundColor: `#2ecaac` }}>상시모집</li>
+                        <li style={{ gridColumn: `3/7`, backgroundColor: `#54c6f9` }}>1-1차 Piscine</li>
+                        <li style={{ gridColumn: `20/24`, backgroundColor: `#54c6f9` }}>1-2차 Piscine</li>
+                        <li style={{ gridColumn: `28/32`, backgroundColor: `#54c6f9` }}>2-1차 Piscine</li>
                     </ul>
                 </div>
                 <div className={styles.gantt__row}>
@@ -54,8 +70,9 @@ export default function YearlyCalendar() {
                         SSAFY
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `5/6`, backgroundColor: `#2ecaac` }}>4기 모집</li>
-                        <li style={{ gridColumn: `6/7`, backgroundColor: `#ff6252` }}>CBT</li>
+                        <li style={{ gridColumn: `19/24`, backgroundColor: `#2ecaac` }}>모집</li>
+                        <li style={{ gridColumn: `24/25`, backgroundColor: `lightpink` }}></li>
+                        <li style={{ gridColumn: `25/26`, backgroundColor:`orange` }}></li>
                     </ul>
                 </div>
                 <div className={styles.gantt__row}>
@@ -63,9 +80,9 @@ export default function YearlyCalendar() {
                         우아한테크코스
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `10/11`, backgroundColor: `#2ecaac` }}>2기 모집</li>
-                        <li style={{ gridColumn: `11/12`, backgroundColor: `#ff6252` }}>코딩테스트</li>
-                        <li style={{ gridColumn: `12/13`, backgroundColor: `#54c6f9` }}>프리코스</li>
+                        <li style={{ gridColumn: `43/46`, backgroundColor: `#2ecaac` }}>모집</li>
+                        <li style={{ gridColumn: `46/47`, backgroundColor: `lightpink` }}></li>
+                        <li style={{ gridColumn: `48/52`, backgroundColor: `#54c6f9` }}>프리코스</li>
                     </ul>
                 </div>
                 <div className={styles.gantt__row}>
@@ -73,9 +90,10 @@ export default function YearlyCalendar() {
                         네이버 부스트캠프
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `6/7`, backgroundColor: `#2ecaac` }}>모집</li>
-                        <li style={{ gridColumn: `7/8`, backgroundColor: `#ff6252` }}>코딩테스트</li>
-                        <li style={{ gridColumn: `8/9`, backgroundColor: `#54c6f9` }}>부스트캠프 챌린지</li>
+                        <li style={{ gridColumn: `23/27`, backgroundColor: `#2ecaac` }}>모집</li>
+                        <li style={{ gridColumn: `27/28`, backgroundColor: `lightpink` }}>1</li>
+                        <li style={{ gridColumn: `28/29`, backgroundColor: `lightpink` }}>2</li>
+                        <li style={{ gridColumn: `30/33`, backgroundColor: `#54c6f9` }}>챌린지</li>
                     </ul>
                 </div>
             </div>

--- a/front/components/YearlyCalendar.js
+++ b/front/components/YearlyCalendar.js
@@ -8,12 +8,12 @@ export default function YearlyCalendar() {
             <div className={styles.header}>
                 <h2>2020년 부트캠프</h2>
                 <p>무료 부트캠프 일정을 한 눈에 확인하세요.</p>
-                <ul className={styles.gantt__tags}>
+                {/* <ul className={styles.gantt__tags}>
                         <li style={{  backgroundColor: `#2ecaac` }}>모집</li>
                         <li style={{  backgroundColor: `lightpink` }}>온라인 코딩테스트</li>
                         <li style={{  backgroundColor: `#54c6f9` }}>오프라인 코딩테스트</li>
                         <li style={{  backgroundColor: `orange` }}>면접</li>
-                </ul>
+                </ul> */}
             </div>
             <div className={styles.gantt}>
                 <div className={classNames({[styles.gantt__row]: true, [styles.gantt__row__months]: true})}>
@@ -33,7 +33,7 @@ export default function YearlyCalendar() {
                         <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
-                        <span></span><span className={styles.marker}></span><span></span>
+                        <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
                         <span></span><span></span><span></span>
@@ -50,14 +50,14 @@ export default function YearlyCalendar() {
                     <ul className={styles.gantt__row__bars}>
                         <li className={styles.calendar_entry} style={{ gridColumn: `4/8`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
                             <span className={styles.calendar_entry__date}>1/22 - 3/10</span>
-                            <span className={styles.calendar_entry__title}>모집</span>
+                            <span className={styles.calendar_entry__title}>지원</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
                             
                             {/* <span className={styles.calendar_entry__category}>Meeting</span> */}
                         </li>
-                        <li className={styles.calendar_entry} style={{ gridColumn: `10/14`, backgroundColor: `lightpink` }}>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `10/14`, backgroundColor: `#54c6f9` }}>
                             <span className={styles.calendar_entry__date}>1/22 - 3/10</span>
-                            <span className={styles.calendar_entry__title}>테스트</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
                             <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
                         </li>
                     </ul>
@@ -68,10 +68,22 @@ export default function YearlyCalendar() {
                         42 Seoul
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `1/53`, backgroundColor: `#2ecaac` }}>상시모집</li>
-                        <li style={{ gridColumn: `3/7`, backgroundColor: `#54c6f9` }}>1-1차 Piscine</li>
-                        <li style={{ gridColumn: `20/24`, backgroundColor: `#54c6f9` }}>1-2차 Piscine</li>
-                        <li style={{ gridColumn: `28/32`, backgroundColor: `#54c6f9` }}>2-1차 Piscine</li>
+                        <li style={{ gridColumn: `1/53`, backgroundColor: `#2ecaac` }}>지원</li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `3/7`, backgroundColor: `#54c6f9` }}>
+                            <span className={styles.calendar_entry__date}>1/23 - 2/16</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `20/24`, backgroundColor: `#54c6f9`, zIndex: `1` }}>
+                            <span className={styles.calendar_entry__date}>5/29 - 6/25</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `28/32`, backgroundColor: `#54c6f9` }}>
+                            <span className={styles.calendar_entry__date}>7/1 - 7/30</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
                     </ul>
                 </div>
                 <div className={styles.gantt__row}>
@@ -79,9 +91,16 @@ export default function YearlyCalendar() {
                         SSAFY
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `19/24`, backgroundColor: `#2ecaac` }}>모집</li>
-                        <li style={{ gridColumn: `24/25`, backgroundColor: `lightpink` }}></li>
-                        <li style={{ gridColumn: `25/26`, backgroundColor:`orange` }}></li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `19/22`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                            <span className={styles.calendar_entry__date}>5/11 - 5/25</span>
+                            <span className={styles.calendar_entry__title}>지원</span>
+                            <span className={styles.calendar_entry__details}><a>4기</a></span>
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `23/26`, backgroundColor: `#54c6f9` }}>
+                            <span className={styles.calendar_entry__date}>7/1 - 7/30</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
                     </ul>
                 </div>
                 <div className={styles.gantt__row}>
@@ -89,9 +108,16 @@ export default function YearlyCalendar() {
                         우아한테크코스
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `43/46`, backgroundColor: `#2ecaac` }}>모집</li>
-                        <li style={{ gridColumn: `46/47`, backgroundColor: `lightpink` }}></li>
-                        <li style={{ gridColumn: `48/52`, backgroundColor: `#54c6f9` }}>프리코스</li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `44/47`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                            <span className={styles.calendar_entry__date}>5/11 - 5/25</span>
+                            <span className={styles.calendar_entry__title}>지원</span>
+                            <span className={styles.calendar_entry__details}><a>4기</a></span>
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `47/52`, backgroundColor: `#54c6f9` }}>
+                            <span className={styles.calendar_entry__date}>7/1 - 7/30</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
                     </ul>
                 </div>
                 <div className={styles.gantt__row}>
@@ -99,10 +125,16 @@ export default function YearlyCalendar() {
                         네이버 부스트캠프
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `23/27`, backgroundColor: `#2ecaac` }}>모집</li>
-                        <li style={{ gridColumn: `27/28`, backgroundColor: `lightpink` }}>1</li>
-                        <li style={{ gridColumn: `28/29`, backgroundColor: `lightpink` }}>2</li>
-                        <li style={{ gridColumn: `30/33`, backgroundColor: `#54c6f9` }}>챌린지</li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `23/27`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                            <span className={styles.calendar_entry__date}>5/11 - 5/25</span>
+                            <span className={styles.calendar_entry__title}>지원</span>
+                            <span className={styles.calendar_entry__details}><a>4기</a></span>
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `27/33`, backgroundColor: `#54c6f9` }}>
+                            <span className={styles.calendar_entry__date}>7/1 - 7/30</span>
+                            <span className={styles.calendar_entry__title}>선발</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/front/components/YearlyCalendar.js
+++ b/front/components/YearlyCalendar.js
@@ -48,9 +48,18 @@ export default function YearlyCalendar() {
                         SW 마에스트로
                     </div>
                     <ul className={styles.gantt__row__bars}>
-                        <li style={{ gridColumn: `4/8`, backgroundColor: `#2ecaac` }}>모집</li>
-                        <li style={{ gridColumn: `12/13`, backgroundColor: `lightpink` }}></li>
-                        <li style={{ gridColumn: `13/14`, backgroundColor:`orange` }}></li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `4/8`, backgroundColor: `#2ecaac`, zIndex: `1` }}>
+                            <span className={styles.calendar_entry__date}>1/22 - 3/10</span>
+                            <span className={styles.calendar_entry__title}>모집</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                            
+                            {/* <span className={styles.calendar_entry__category}>Meeting</span> */}
+                        </li>
+                        <li className={styles.calendar_entry} style={{ gridColumn: `10/14`, backgroundColor: `lightpink` }}>
+                            <span className={styles.calendar_entry__date}>1/22 - 3/10</span>
+                            <span className={styles.calendar_entry__title}>테스트</span>
+                            <span className={styles.calendar_entry__details}><a>자세히보기</a></span>
+                        </li>
                     </ul>
                     <ul className={styles.gantt__row__bars}></ul>
                 </div>

--- a/front/components/YearlyCalendar.module.css
+++ b/front/components/YearlyCalendar.module.css
@@ -8,7 +8,7 @@
 
 .header {
   color: #202125;
-  margin-bottom: 40px;
+  margin-bottom: 0px;
 }
 .header h2 {
   font-weight: 600;
@@ -57,7 +57,7 @@
 }
 .gantt__row__lines {
   position: absolute;
-  height: 100%;
+  height: 200%;
   width: 100%;
   background-color: transparent;
   grid-template-columns: 150px repeat(52, 1fr); /*경계선 : repeat 함수로 쪼갤 수 있음*/ 
@@ -115,8 +115,9 @@
   border-top: 1px solid rgba(221, 221, 221, 0.8);
 }
 .gantt__row__bars li {
+  max-height: 30px;
   font-weight: 500;
-  text-align: left;
+  text-align: center;
   font-size: 14px;
   min-height: 15px;
   background-color: #55de84;
@@ -151,14 +152,13 @@
   display: grid;
   padding: 9px 0;
   margin: 0;
-  grid-template-columns: repeat(365, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   grid-gap: 8px 0;
-  border-top: 1px solid rgba(221, 221, 221, 0.8);
 }
 
 .gantt__tags li {
   font-weight: 500;
-  text-align: left;
+  text-align: center;
   font-size: 14px;
   min-height: 15px;
   background-color: #55de84;
@@ -168,4 +168,5 @@
   position: relative;
   cursor: pointer;
   border-radius: 20px;
+  margin: 0px 3px;
 }

--- a/front/components/YearlyCalendar.module.css
+++ b/front/components/YearlyCalendar.module.css
@@ -60,7 +60,7 @@
   height: 200%;
   width: 100%;
   background-color: transparent;
-  grid-template-columns: 150px repeat(52, 1fr); /*경계선 : repeat 함수로 쪼갤 수 있음*/ 
+  grid-template-columns: 150px repeat(12, 1fr); /*경계선 : repeat 함수로 쪼갤 수 있음*/ 
 }
 .gantt__row__lines span {
   display: block;
@@ -79,13 +79,13 @@
 }
 .gantt__row__months {
   color: #fff;
-  background-color: #0a3444 !important;
+  background-color: #4A91F5 !important;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   grid-template-columns: 150px repeat(12, 1fr); /*1~12월 : repeat 함수로 쪼갤 수 있음*/
 }
 .gantt__row__months .gantt__row__first {
   border-top: 0 !important;
-  background-color: #0a3444 !important;
+  background-color: #4A91F5 !important;
 }
 .gantt__row__months span {
   text-align: center;
@@ -178,11 +178,10 @@
   width: auto;
   border-radius: 3px;
   box-sizing: border-box;
-  border: 1px solid rgba(0, 0, 0, 0.08);
   transition: 0.3s;
   color: white;
   font-family: sans-serif;
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1;
   display: flex;
   flex-direction: column;
@@ -190,13 +189,14 @@
   margin: 1px;
 }
 .calendar_entry__title {
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 600;
   padding-top: 4px;
   padding-bottom: 4px;
   text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.04);
 }
 .calendar_entry__date, .calendar_entry__details {
+  font-size: 13px;
   opacity: 0;
   transition: 0.3s;
   height: 0;
@@ -217,7 +217,7 @@
   transition: 0.3s;
 }
 .calendar_entry:hover {
-  width: 292px;
+  width: 200px;
   cursor: pointer;
   padding: 12px;
   -webkit-box-shadow: 1px 2px 10px 0px rgba(32, 41, 56, 0.4);

--- a/front/components/YearlyCalendar.module.css
+++ b/front/components/YearlyCalendar.module.css
@@ -1,0 +1,171 @@
+.test1{
+    background-color: #55de84;
+}
+.test2{
+    
+    color: bisque;
+}
+
+.header {
+  color: #202125;
+  margin-bottom: 40px;
+}
+.header h2 {
+  font-weight: 600;
+}
+.header p {
+  font-weight: 300;
+}
+.wrapper {
+  max-width: 1200px;
+  min-width: 700px;
+  margin: 0 auto;
+  padding: 40px;
+}
+.gantt {
+  display: grid;
+  border: 0;
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  box-shadow: 0 75px 125px -57px #7e8f94;
+}
+.gantt__row {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  background-color: #fff;
+}
+.gantt__row:nth-child(odd) {
+  background-color: #f5f5f5;
+}
+.gantt__row:nth-child(odd) .gantt__row__first {
+  background-color: #f5f5f5;
+}
+.gantt__row:nth-child(3) .gantt__row__bars {
+  border-top: 0;
+}
+.gantt__row:nth-child(3) .gantt__row__first {
+  border-top: 0;
+}
+.gantt__row__empty {
+  background-color: #ffd6d2 !important;
+  z-index: 1;
+}
+.gantt__row__empty .gantt__row__first {
+  border-width: 1px 1px 0 0;
+}
+.gantt__row__lines {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  background-color: transparent;
+  grid-template-columns: 150px repeat(52, 1fr); /*경계선 : repeat 함수로 쪼갤 수 있음*/ 
+}
+.gantt__row__lines span {
+  display: block;
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+}
+.gantt__row__lines span.marker {
+  background-color: rgba(10, 52, 68, 0.13);
+  z-index: 2;
+}
+.gantt__row__lines:after {
+  grid-row: 1;
+  grid-column: 0;
+  background-color: #1688b345;
+  z-index: 2;
+  height: 100%;
+}
+.gantt__row__months {
+  color: #fff;
+  background-color: #0a3444 !important;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  grid-template-columns: 150px repeat(12, 1fr); /*1~12월 : repeat 함수로 쪼갤 수 있음*/
+}
+.gantt__row__months .gantt__row__first {
+  border-top: 0 !important;
+  background-color: #0a3444 !important;
+}
+.gantt__row__months span {
+  text-align: center;
+  font-size: 13px;
+  align-self: center;
+  font-weight: bold;
+  padding: 20px 0;
+}
+.gantt__row__first {
+  background-color: #fff;
+  border-width: 1px 0 0 0;
+  border-color: rgba(0, 0, 0, 0.1);
+  border-style: solid;
+  padding: 15px 0;
+  font-size: 13px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.gantt__row__bars {
+  list-style: none;
+  display: grid;
+  padding: 9px 0;
+  margin: 0;
+  grid-template-columns: repeat(52, 1fr); /* 칸 : repeat 함수로 쪼갤 수 있음*/
+  grid-gap: 8px 0;
+  border-top: 1px solid rgba(221, 221, 221, 0.8);
+}
+.gantt__row__bars li {
+  font-weight: 500;
+  text-align: left;
+  font-size: 14px;
+  min-height: 15px;
+  background-color: #55de84;
+  padding: 5px 12px;
+  color: #fff;
+  overflow: hidden;
+  position: relative;
+  cursor: pointer;
+  border-radius: 20px;
+}
+.gantt__row__bars li.stripes {
+  background-image: repeating-linear-gradient(45deg, transparent, transparent 5px, rgba(255, 255, 255, 0.1) 5px, rgba(255, 255, 255, 0.1) 12px);
+}
+.gantt__row__bars li:before, .gantt__row__bars li:after {
+  content: "";
+  height: 100%;
+  top: 0;
+  z-index: 4;
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.3);
+}
+.gantt__row__bars li:before {
+  left: 0;
+}
+.gantt__row__bars li:after {
+  right: 0;
+}
+
+/* 헤더 밑 태그 테스트용 gantt__row-bars 와 같음*/
+.gantt__tags {
+  list-style: none;
+  display: grid;
+  padding: 9px 0;
+  margin: 0;
+  grid-template-columns: repeat(365, 1fr);
+  grid-gap: 8px 0;
+  border-top: 1px solid rgba(221, 221, 221, 0.8);
+}
+
+.gantt__tags li {
+  font-weight: 500;
+  text-align: left;
+  font-size: 14px;
+  min-height: 15px;
+  background-color: #55de84;
+  padding: 5px 12px;
+  color: #fff;
+  overflow: hidden;
+  position: relative;
+  cursor: pointer;
+  border-radius: 20px;
+}

--- a/front/components/YearlyCalendar.module.css
+++ b/front/components/YearlyCalendar.module.css
@@ -37,10 +37,10 @@
   background-color: #fff;
 }
 .gantt__row:nth-child(odd) {
-  background-color: #f5f5f5;
+  background-color: #F2F8FF;
 }
 .gantt__row:nth-child(odd) .gantt__row__first {
-  background-color: #f5f5f5;
+  background-color: #F2F8FF;
 }
 .gantt__row:nth-child(3) .gantt__row__bars {
   border-top: 0;
@@ -145,33 +145,7 @@
   right: 0;
 }
 
-/* 헤더 밑 태그 테스트용 gantt__row-bars 와 같음*/
-.gantt__tags {
-  list-style: none;
-  display: grid;
-  padding: 9px 0;
-  margin: 0;
-  grid-template-columns: repeat(4, 1fr);
-  grid-gap: 8px 0;
-}
-
-.gantt__tags li {
-  font-weight: 500;
-  text-align: center;
-  font-size: 14px;
-  min-height: 15px;
-  background-color: #55de84;
-  padding: 5px 12px;
-  color: #fff;
-  overflow: hidden;
-  position: relative;
-  cursor: pointer;
-  border-radius: 20px;
-  margin: 0px 3px;
-}
-
 /* calendar hover  */
-
 .calendar_entry {
   background: #61cd8b;
   padding: 0 4px;

--- a/front/components/YearlyCalendar.module.css
+++ b/front/components/YearlyCalendar.module.css
@@ -115,7 +115,6 @@
   border-top: 1px solid rgba(221, 221, 221, 0.8);
 }
 .gantt__row__bars li {
-  max-height: 30px;
   font-weight: 500;
   text-align: center;
   font-size: 14px;
@@ -169,4 +168,68 @@
   cursor: pointer;
   border-radius: 20px;
   margin: 0px 3px;
+}
+
+/* calendar hover  */
+
+.calendar_entry {
+  background: #61cd8b;
+  padding: 0 4px;
+  width: auto;
+  border-radius: 3px;
+  box-sizing: border-box;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  transition: 0.3s;
+  color: white;
+  font-family: sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  margin: 1px;
+}
+.calendar_entry__title {
+  font-size: 13.5px;
+  font-weight: 600;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.04);
+}
+.calendar_entry__date, .calendar_entry__details {
+  opacity: 0;
+  transition: 0.3s;
+  height: 0;
+  visibility: hidden;
+  text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.04);
+}
+.calendar_entry__date a, .calendar_entry__details a {
+  text-decoration: underline;
+}
+.calendar_entry__category {
+  position: absolute;
+  font-weight: 600;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.16);
+  right: 4px;
+  top: 2px;
+  border-radius: 2px;
+  transition: 0.3s;
+}
+.calendar_entry:hover {
+  width: 292px;
+  cursor: pointer;
+  padding: 12px;
+  -webkit-box-shadow: 1px 2px 10px 0px rgba(32, 41, 56, 0.4);
+  -moz-box-shadow: 1px 2px 10px 0px rgba(32, 41, 56, 0.4);
+  box-shadow: 1px 2px 10px 0px rgba(32, 41, 56, 0.4);
+}
+.calendar_entry:hover .calendar_entry__category {
+  right: 12px;
+  top: 12px;
+}
+.calendar_entry:hover .calendar_entry__date, .calendar_entry:hover .calendar_entry__details {
+  opacity: 1;
+  height: 12px;
+  visibility: visible;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -3486,6 +3486,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6375,6 +6384,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -7986,7 +8001,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         }
       }
     },
@@ -9149,6 +9168,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9722,7 +9747,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -15369,7 +15398,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -15695,7 +15728,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "get-caller-file": {
           "version": "1.0.3",

--- a/front/pages/index.js
+++ b/front/pages/index.js
@@ -9,7 +9,6 @@ import Subtitle from "../components/Subtitle";
 const Home = () => {
   return (
       <Layout>
-      	<TextLogo/>
         <Jumbotron />
         <Title> 내 일정에 맞는 부트캠프 찾기 </Title>
       	<YearlyCalendar />
@@ -17,17 +16,6 @@ const Home = () => {
         <Title> 한 눈에 보는 부트캠프 </Title>
         <Table />
       </Layout>
-=======
-
-
-const Home = () => {
-  return (
-    <>
-      {/*<Layout>*/}
-      {/*  <div>Hello, Next!</div>*/}
-      {/*</Layout>*/}
-    </>
->>>>>>> Add YearlyCalendar
   );
 }
 

--- a/front/pages/index.js
+++ b/front/pages/index.js
@@ -1,18 +1,33 @@
 import Layout from '../components/Layout';
 import Jumbotron from "../components/Jumbotron";
 import Table from "../components/Table";
+import TextLogo from '../components/TextLogo';
+import YearlyCalendar from '../components/YearlyCalendar';
 import Title from "../components/Title";
 import Subtitle from "../components/Subtitle";
 
 const Home = () => {
   return (
       <Layout>
+      	<TextLogo/>
         <Jumbotron />
         <Title> 내 일정에 맞는 부트캠프 찾기 </Title>
+      	<YearlyCalendar />
         <Subtitle> (연간일정 추가) </Subtitle>
         <Title> 한 눈에 보는 부트캠프 </Title>
         <Table />
       </Layout>
+=======
+
+
+const Home = () => {
+  return (
+    <>
+      {/*<Layout>*/}
+      {/*  <div>Hello, Next!</div>*/}
+      {/*</Layout>*/}
+    </>
+>>>>>>> Add YearlyCalendar
   );
 }
 


### PR DESCRIPTION
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/37580034/87111894-6fd76180-c2a5-11ea-8ade-3d3ea5a0252f.png">

 - Add yearly calendar components.
 - The recruitment process was largely divided into four types: `support`/`test`/`education and test`/`education`.
 - `Education and test` means a course that has both characteristics of education and test, such as the `boost challenge` of BoostCamp or `piscine`.
 - `Education and test`  will use the original course name of each bootcamps.
 - Detailed steps(hover).

#### What to add

- CTA
- Problem of being cut off on an Eleg course hover.
- Hover Details
- Add a link on the program names.

---

 - 연간일정 컴포넌트를 추가했습니다.
 - 모집과정은 크게 지원/선발/교육및선발/교육시작 4종류로 구분했습니다.
 - 교육및선발은 피씬이나 부스트캠프의 챌린지 같은 교육과 선발의 성격을 둘 다 갖는 과정을 말합니다.
 - 교육및선발은 각 부트캠프의 원래 코스 이름을 그대로 사용합니다.
 - 각 종류의 자세한 단계는 hover 시 보여줍니다.

#### 추가예정

- CTA
- 우아한테크코스 일정 호버 시 잘리는 문제
- hover 상세 내용
- 프로그램 이름에 링크 추가
 