### PR TITLE
add timeline shadow, modify font to Nanum BarunGothic

### DIFF
--- a/front/components/Header.module.css
+++ b/front/components/Header.module.css
@@ -2,7 +2,7 @@
     margin: 160px 0 50px 0;
     display: block;
     text-align: center;
-    font-family: 'NanumGothic';
+    font-family: 'Nanum BarunGothic';
 }
 
 .header h1 {

--- a/front/components/HorizontalTimeline.module.css
+++ b/front/components/HorizontalTimeline.module.css
@@ -1,10 +1,9 @@
 
-@import url(//fonts.googleapis.com/earlyaccess/nanumgothic.css); .nanumgothic * { font-family: 'Nanum Gothic', sans-serif; }
-@font-face { font-family: 'LAB디지털'; src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-07@1.0/LAB디지털.woff') format('woff'); font-weight: normal; font-style: normal; }
+@import url(//fonts.googleapis.com/earlyaccess/nanumBarunGothic.css); .nanumBarunGothic * { font-family: 'Nanum BarunGothic', sans-serif; }
 
 
 .body {
-  font: normal 16px/1.5 "Nanum Gothic";
+  font: normal 16px/1.5 "Nanum BarunGothic";
   background: #F2F8FF;
   margin: 0 auto;
   width: 100%;
@@ -14,7 +13,7 @@
 }
 
 .body * {
-  font-family: "Nanum Gothic";
+  font-family: "Nanum BarunGothic";
 }
 
 
@@ -80,9 +79,9 @@
   position: absolute;
   /*display: inline-block;*/
   width: 100%;
-  height: 3px;
+  height: 7px;
   background: white;
-  top: 606px;
+  top: 603.5px;
 }
 
 
@@ -144,11 +143,19 @@
   font-size: 1.1rem;
   white-space: normal;
   font-weight: 600;
-  border-radius: 5px 5px 5px 5px;
-  font-family: 'Nanum Gothic';
-  box-shadow: 2px 2px 3px 1px #DBE4EE;
+  font-family: 'Nanum BarunGothic';
+  /*box-shadow: 2px 2px 3px 1px #DBE4EE;*/
+  box-shadow: 10px 10px 20px 5px #cdd2d9;
 }
 
+.timeline ol li .card:nth-child(odd) {
+
+  border-radius: 12px 12px 12px 0;
+}
+
+.timeline ol li:nth-child(even) .card {
+  border-radius: 0 12px 12px 12px;
+}
 
 .card_end {
   background: #DFE8F4;
@@ -208,7 +215,7 @@
 /* ODD */
 .timeline ol li:nth-child(odd) .card {
   top: -16px;
-  transform: translateY(-100%);
+  transform: translateY(-115%);
 }
 
 .timeline ol li:nth-child(odd) .card::before {
@@ -251,7 +258,7 @@
 
 /* 라인에서 얼마나 떨어졌는지 */
 .timeline ol li:nth-child(even) .card {
-  top: calc(100% + 16px);
+  top: calc(100% + 30px);
 }
 /*-----------------------------------------------------------------------*/
 

--- a/front/components/Jumbotron.module.css
+++ b/front/components/Jumbotron.module.css
@@ -26,6 +26,8 @@
 /*}*/
 
  @import url(//fonts.googleapis.com/earlyaccess/nanumgothic.css); .nanumgothic * { font-family: 'Nanum Gothic', sans-serif; }
+ @import url(//fonts.googleapis.com/earlyaccess/nanumBarunGothic.css); .nanumBarunGothic * { font-family: 'Nanum BarunGothic', sans-serif; }
+
 
  .box {
     overflow: auto;
@@ -43,7 +45,7 @@
 .nav {
     display: inline;
     line-height: 3;
-    font-family: 'Nanum Gothic';
+    font-family: 'Nanum BarunGothic';
     font-size: 16px;
     font-weight: 500;
     width: 100px;
@@ -78,7 +80,7 @@
     padding-right: 4rem;
     position: absolute;
     top: 28%;
-    font-family: 'NanumGothic';
+    font-family: 'Nanum BarunGothic';
     max-width: 80%;
  }
 

--- a/front/components/Table.module.css
+++ b/front/components/Table.module.css
@@ -22,6 +22,8 @@
 /*}*/
 
 @import url(//fonts.googleapis.com/earlyaccess/nanumgothic.css); .nanumgothic * { font-family: 'Nanum Gothic', sans-serif; }
+@import url(//fonts.googleapis.com/earlyaccess/nanumBarunGothic.css); .nanumBarunGothic * { font-family: 'Nanum BarunGothic', sans-serif; }
+
 
 /*
     Badge
@@ -70,7 +72,7 @@
     max-width: 1200px;
     width: 92%;
     margin: 0 auto;
-    font-family: "Nanum Gothic";
+    font-family: "Nanum BarunGothic";
     color: #615E67;
     margin-bottom: 170px;
 }

--- a/front/components/YearlyCalendar.module.css
+++ b/front/components/YearlyCalendar.module.css
@@ -1,4 +1,6 @@
-@import url(//fonts.googleapis.com/earlyaccess/nanumgothic.css); .nanumgothic * { font-family: 'Nanum Gothic', sans-serif; }
+@import url(//fonts.googleapis.com/earlyaccess/nanumgothic.css); .nanumgothic * { font-family: 'Nanum BarunGothic', sans-serif; }
+@import url(//fonts.googleapis.com/earlyaccess/nanumBarunGothic.css); .nanumBarunGothic * { font-family: 'Nanum BarunGothic', sans-serif; }
+
 
 @media only screen and (orientation: portrait) {
   .landscape_only  { display: none; }
@@ -21,7 +23,7 @@
   font-weight: 300;
 }
 .wrapper {
-  font-family: 'Nanum Gothic';
+  font-family: 'Nanum BarunGothic';
   font-weight: 800;
   text-align: center;
   font-size: 18px;
@@ -29,7 +31,7 @@
   min-width: 700px;
   margin: 0 auto;
   width: 92%;
-  font-family: "Nanum Gothic";
+  font-family: "Nanum BarunGothic";
 }
 .gantt {
   display: grid;
@@ -184,7 +186,7 @@
   box-sizing: border-box;
   transition: 0.3s;
   color: white;
-  font-family: 'Nanum Gothic';
+  font-family: 'Nanum BarunGothic';
   font-size: 13px;
   line-height: 1;
   display: flex;


### PR DESCRIPTION
## 부스트캠프 상세페이지 Timeline 
- 라인 두께를 3px 에서 7px로 조정
- 그림자 추가
- 카드와 라인 사이 공백 추가

## 폰트
- 나눔고딕에서 나눔바른고딕으로 변경