### PR TITLE
Refactor port number and Remove pubile build folder

### DIFF
--- a/back/app.js
+++ b/back/app.js
@@ -26,7 +26,6 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
-app.use(express.static(path.join(__dirname, '../front/build')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);

--- a/back/bin/www
+++ b/back/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '80');
+var port = normalizePort(process.env.PORT || '5000');
 app.set('port', port);
 
 /**


### PR DESCRIPTION
Port of express has changed from 80 to 5000.
Since there wasn't nginx, express listened directly via 80 port.
But now that we have nginx which listens 80 port, express need to listen 5000 port again.
And the code to load `build folder` which is made from create react app.

---

express가 돌리는 백서버 포트를 80에서 5000으로 바꾸었습니다.
원래는 nginx가 없었기 때문에 api.yebalja.com으로 접속했을때 바로 express로 접속하게 했었는데
이제는 nginx가 80포트와 443포트를 listen하고 있기 때문에 express를 5000으로 되돌려놨습니다.
또한 create react app으로 만들었던 build폴더를 접근하기 위해 필요했던 static 코드를 지웠습니다.
(대리님이 만들었던 프론트 화면을 불러오기 위해 필요했던 부분)