### PR TITLE
Modify Faq Component's CSS

### DIFF
--- a/front/components/FAQ.js
+++ b/front/components/FAQ.js
@@ -5,26 +5,27 @@ import Tab from "react-bootstrap/Tab"
 import Tabs from "react-bootstrap/Tabs"
 import classNames from 'classnames';
 
-
 function QnA ({list}) {
+
   return (
     <>
-      <strong>Q. {list.q}</strong>
-      <br />A. {list.a}
-      <br /><br />
+      <div className={styles.question}>Q. {list.q}</div>
+      <div className={styles.answer}>{list.a}</div>
     </>
   );
 };
 
-function TabLeft({sub}) {
+function SecondTab({sub}) {
+
   return (
-    <ListGroup.Item action href={sub.href}>
+    <ListGroup.Item href={sub.href} className={styles.listitem}>
       {sub.title}
     </ListGroup.Item>
   )
 }
 
-function TabRight ({sub}) { 
+function ContentBox ({sub}) {
+
   return (
     <Tab.Pane eventKey={sub.href}>
       {sub.qna.map((v, idx) => <QnA list={v} key={idx} />)}
@@ -33,22 +34,16 @@ function TabRight ({sub}) {
 }
 
 function FaqTab({subList}) {
-  return (
-    <div className={classNames({["row"]: true, ["justify-content-md-center"]: true})}>
-      <Tab.Container id="list-group-tabs-example" defaultActiveKey={subList[0].href}>
-        <div className={"col-md-3"}>
-          <ListGroup className={styles.secondTab}>
-            {subList.map((v, idx) => <TabLeft sub={v} key={idx} />)}
-          </ListGroup>
-        </div>
 
-        <div className={classNames({["col-md-9"]: true, [styles.content]: true})}>
-          <Tab.Content>
-            {subList.map((v, idx) => <TabRight sub={v} key={idx} />)}
-          </Tab.Content>
-        </div>
-      </Tab.Container>
-    </div>
+  return (
+    <Tab.Container defaultActiveKey={subList[0].href}>
+      <ListGroup horizontal className={styles.subTab}>
+        {subList.map((v, idx) => <SecondTab sub={v} key={idx} />)}
+      </ListGroup>
+      <Tab.Content className={styles.content}>
+        {subList.map((v, idx) => <ContentBox sub={v} key={idx} />)}
+      </Tab.Content>
+    </Tab.Container>
   );
 }
 
@@ -57,7 +52,7 @@ export default function Faq({program}) {
   const allDataList = {
     "ftseoul" : [
       {
-        "category" : "지원/선발",
+        "category" : "지원선발",
         "eventKey" : "apply",
         "subCategory": [
             {
@@ -144,7 +139,7 @@ export default function Faq({program}) {
             }
         ]
     },{
-        "category": "기타",
+        "category": "기타사항",
         "eventKey": "etc",
         "subCategory": [
             {
@@ -175,7 +170,7 @@ export default function Faq({program}) {
     ],
     "ssafy" : [
       {
-        "category" : "지원/선발",
+        "category" : "지원선발",
         "eventKey" : "apply",
         "subCategory": [
             {
@@ -252,7 +247,7 @@ export default function Faq({program}) {
             }
         ]
     },{
-        "category": "기타",
+        "category": "기타사항",
         "eventKey": "etc",
         "subCategory": [
             {
@@ -270,7 +265,7 @@ export default function Faq({program}) {
     ],
     "boostcamp" : [
       {
-        "category" : "지원/선발",
+        "category" : "지원선발",
         "eventKey" : "apply",
         "subCategory": [
             {
@@ -350,7 +345,7 @@ export default function Faq({program}) {
             }
         ]
     },{
-        "category": "기타",
+        "category": "기타사항",
         "eventKey": "etc",
         "subCategory": [
             {
@@ -378,7 +373,7 @@ export default function Faq({program}) {
     ],
     "soma" : [
       {
-        "category" : "지원/선발",
+        "category" : "지원선발",
         "eventKey" : "apply",
         "subCategory": [
             {
@@ -448,7 +443,7 @@ export default function Faq({program}) {
             }
         ]
     },{
-        "category": "기타",
+        "category": "기타사항",
         "eventKey": "etc",
         "subCategory": [
             {
@@ -479,7 +474,7 @@ export default function Faq({program}) {
     ],
     "woowa" : [
       {
-        "category" : "지원/선발",
+        "category" : "지원선발",
         "eventKey" : "apply",
         "subCategory": [
             {
@@ -562,7 +557,7 @@ export default function Faq({program}) {
             }
         ]
     },{
-        "category": "기타",
+        "category": "기타사항",
         "eventKey": "etc",
         "subCategory": [
             {
@@ -590,7 +585,7 @@ export default function Faq({program}) {
     ],
     "likelion" : [
       {
-        "category" : "지원/선발",
+        "category" : "지원선발",
         "eventKey" : "apply",
         "subCategory": [
             {
@@ -652,7 +647,7 @@ export default function Faq({program}) {
             }
         ]
     },{
-        "category": "기타",
+        "category": "기타사항",
         "eventKey": "etc",
         "subCategory": [
             {
@@ -673,13 +668,14 @@ export default function Faq({program}) {
   let dataList = allDataList[program];
 
   return (
-    <div className={styles.firstTab}>
-      <Tabs defaultActiveKey={dataList[0].eventKey} transition={false}>
-        {dataList.map((v, idx) => (
-          <Tab eventKey={v.eventKey} title={v.category} key={idx}>
-            <FaqTab subList={v.subCategory} key={idx}/>
-          </Tab>
-        ))}
+    <div className={styles.container}>
+      <Tabs defaultActiveKey={dataList[0].eventKey} transition={false}
+        className={classNames({ "justify-content-center": true, [styles.mainTab]: true })}>              
+          {dataList.map((v, idx) => (
+            <Tab eventKey={v.eventKey} title={v.category} key={idx}>
+              <FaqTab subList={v.subCategory} key={idx}/>
+            </Tab>
+          ))}
       </Tabs>
     </div>
   );

--- a/front/components/FAQ.js
+++ b/front/components/FAQ.js
@@ -19,7 +19,7 @@ function SecondTab({sub}) {
 
   return (
     <ListGroup.Item href={sub.href} className={styles.listitem}>
-      {sub.title}
+      · {sub.title} ·
     </ListGroup.Item>
   )
 }

--- a/front/components/FAQ.js
+++ b/front/components/FAQ.js
@@ -9,7 +9,7 @@ function QnA ({list}) {
 
   return (
     <>
-      <div className={styles.question}>Q. {list.q}</div>
+      <div className={styles.question}>{list.q}</div>
       <div className={styles.answer}>{list.a}</div>
     </>
   );

--- a/front/components/FAQ.module.css
+++ b/front/components/FAQ.module.css
@@ -1,13 +1,117 @@
-.firstTab {
-  margin-left: 10%;
-  margin-right: 10%;
+.container {
+  max-width: 800px;
+  min-height: 300px;;
+  margin: 0 auto;
+  padding: 0;
+  width: 65%;
+  height: auto;
+  font-family: "NanumBarunGothic";
 }
 
-.secondTab {
-  margin-top: 30px;
-  align-content: center;
+/* MainTab */
+.mainTab a {
+  padding: 10px 0;
+  font-size: 1.2em;
+  min-width: 120px;
+  text-align: center;
+  font-weight: 600;
+  color: #89A1C3;
+  outline: none;
 }
 
+/* SubTab */
+.subTab {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width:100%;
+}
+
+.subTab div {
+  font-size: 1.0em;
+  font-weight: 400;
+  color: rgba(255,255,255,.5);
+  border: none;
+  border-radius: 30px !important;
+  max-width: 400px;
+  margin: 20px 7px !important;
+  padding: 3px 14px;
+  height: 100%;
+  box-shadow: 1px 1px 3px 2px rgba(0, 0, 0, 0.2);
+  outline: none;
+  background-color: #4A91F5 !important;
+}
+
+.subTab div:hover {
+  color: white;
+  cursor: pointer;
+}
+
+/* Content (Q&A) */
 .content {
-  margin-top: 30px;
+  margin: 30px 10px 0;
+}
+
+.question {
+  font-size: 1.15em;
+  font-weight: 600;
+}
+
+.answer {
+  font-size: 1em;
+  line-height: 1.8;
+  margin: 10px 0 40px;
+}
+
+@media screen and (max-width: 728px) {
+  .container {
+    width: 75%;
+  }
+
+  .mainTab a {
+    font-size: 1.1em;
+    min-width: 90px;
+  }
+
+  .subTab div {
+    font-size: 0.85em;
+    margin: 20px 3px 5px;
+  }
+}
+
+@media screen and (max-width: 588px) {
+  .container {
+    width: 85%;
+  }
+
+  .mainTab a {
+    font-size: 1.1em;
+  }
+
+  .subTab div {
+    font-size: 0.85em;
+    margin: 20px 0px 5px;
+  }
+}
+
+@media screen and (max-width: 348px) {
+  .container {
+    width: 90%;
+  }
+
+  .mainTab a {
+    font-size: 1.0em;
+  }
+
+  .subTab div {
+    font-size: 0.70em;
+  }
+
+  .question {
+    font-size: 0.9em;
+  }
+  
+  .answer {
+    font-size: 0.7em;
+  }
 }

--- a/front/components/FAQ.module.css
+++ b/front/components/FAQ.module.css
@@ -35,9 +35,9 @@
   border-radius: 15px !important;
   max-width: 400px;
   margin: 35px 8px !important;
-  padding: 2px 17px;
+  padding: 2px 14px;
   height: 100%;
-  box-shadow: 1px 1px 4px 2px rgba(0, 0, 0, 0.15);
+  box-shadow: 3px 2px 4px 1px rgba(0, 0, 0, 0.1);
   outline: none;
   background-color: #4A91F5 !important;
 }
@@ -95,11 +95,11 @@
   .subTab div {
     font-size: 0.85em;
     margin: 20px 5px 5px !important;
-    padding: 2px 15px;
+    padding: 2px 12px;
   }
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (max-width: 430px) {
   .container {
     width: 90%;
   }
@@ -112,7 +112,7 @@
   .subTab div {
     font-size: 0.70em;
     margin: 20px 3px 0px !important;
-    padding: 2px 13px;
+    padding: 2px 8px;
   }
 
   .question {

--- a/front/components/FAQ.module.css
+++ b/front/components/FAQ.module.css
@@ -12,7 +12,7 @@
 .mainTab a {
   padding: 10px 0;
   font-size: 1.2em;
-  min-width: 120px;
+  min-width: 140px;
   text-align: center;
   font-weight: 600;
   color: #89A1C3;
@@ -32,12 +32,12 @@
   font-weight: 400;
   color: rgba(255,255,255,.5);
   border: none;
-  border-radius: 30px !important;
+  border-radius: 15px !important;
   max-width: 400px;
-  margin: 20px 7px !important;
-  padding: 3px 14px;
+  margin: 35px 8px !important;
+  padding: 2px 17px;
   height: 100%;
-  box-shadow: 1px 1px 3px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 1px 1px 4px 2px rgba(0, 0, 0, 0.15);
   outline: none;
   background-color: #4A91F5 !important;
 }
@@ -53,15 +53,15 @@
 }
 
 .question {
-  font-size: 1.15em;
+  font-size: 1.2em;
   font-weight: 600;
-  color: #1e2329;
+  color: #3e4955;
 }
 
 .answer {
-  font-size: 1em;
-  line-height: 1.8;
-  margin: 10px 0 40px;
+  font-size: 0.97em;
+  line-height: 2;
+  margin: 10px 20px 45px 20px;
   color: #627083;
 }
 
@@ -73,7 +73,7 @@
 
   .mainTab a {
     font-size: 1.1em;
-    min-width: 90px;
+    min-width: 100px;
   }
 
   .subTab div {
@@ -89,25 +89,30 @@
 
   .mainTab a {
     font-size: 1.1em;
+    min-width: 110px;
   }
 
   .subTab div {
     font-size: 0.85em;
-    margin: 20px 0px 5px;
+    margin: 20px 5px 5px !important;
+    padding: 2px 15px;
   }
 }
 
-@media screen and (max-width: 348px) {
+@media screen and (max-width: 400px) {
   .container {
     width: 90%;
   }
 
   .mainTab a {
     font-size: 1.0em;
+    min-width: 90px;
   }
 
   .subTab div {
     font-size: 0.70em;
+    margin: 20px 3px 0px !important;
+    padding: 2px 13px;
   }
 
   .question {

--- a/front/components/FAQ.module.css
+++ b/front/components/FAQ.module.css
@@ -1,6 +1,6 @@
 .container {
   max-width: 800px;
-  min-height: 300px;;
+  min-height: 400px;
   margin: 0 auto;
   padding: 0;
   width: 65%;
@@ -55,17 +55,20 @@
 .question {
   font-size: 1.15em;
   font-weight: 600;
+  color: #1e2329;
 }
 
 .answer {
   font-size: 1em;
   line-height: 1.8;
   margin: 10px 0 40px;
+  color: #627083;
 }
 
 @media screen and (max-width: 728px) {
   .container {
     width: 75%;
+    min-height: 300px;
   }
 
   .mainTab a {


### PR DESCRIPTION
## Before : Low Design Coherence Problem
  - too short
  - too wide
  - too bouncy color
  - different font
  - different directions of maintab and subtab


## After
- Low Design Coherence
  - set min-height
  - set width to be smaller than 50~90%
  - apply theme color
  - apply theme font
  - set both directions of maintab and subtab horizontal

---
## 변경 전 : 낮은 디자인 일관성 문제
- 컴포넌트 높이가 너무 짧고, 너비는 너무 넓어서 비율이 예쁘지 않음
- 부트스트랩에서 제공하는 기본색상으로 우리 컬러스킴과 맞지 않음
- 폰트적용이 안되있고 전반적으로 단락구성이 너무 단조로움
- 탭 두개가 방향이 달라서 직관적이지 않음

![image](https://user-images.githubusercontent.com/60066472/90166131-b5bba400-ddd4-11ea-8e78-69782e683e2a.png)

## 변경 후
- 미디어쿼리를 생성하고 최소 높이를 적용하여 내용이 짧을 때도 적당한 높이를 갖도록 설정
- 너비를 스크린의 50~90%를 넘지 않게해서 줄글이 지나치게 늘어지는 것 방지
- 컬러스킴 적용하고 최대한 다른 색상 사용 자제 (특히 내비게이션 바의 스타일과 유사하도록 함)
- 폰트 적용 및 폰트스타일 조정(font-weight, line-height, font-size 등)
- 메인탭과 서브탭 두 개모두 가로방향으로 배열하여 좀 더 직관적으로 이중탭 구성으로 변경
- 메인탭에서 "지원/선발" 은 "지원선발"로, "기타"는 "기타사항"으로 4글자로 통일해서 시각적으로 균등하게 차지하도록 함

![image](https://user-images.githubusercontent.com/60066472/90167808-295eb080-ddd7-11ea-8161-96814b306747.png)
