### PR TITLE
Parse json/taelee

### DIFF
--- a/back/routes/json.js
+++ b/back/routes/json.js
@@ -202,4 +202,22 @@ router.get('/reviews', function(req, res, next){
   })
 })
 
+router.get('/navlist', (req,res) => {
+  db.query(`select nav_title as program, link as href from programs;`,
+    (error, result) => {
+      if (error) throw error;
+      console.log(result);
+      res.json(result);
+    })
+})
+
+router.get('/noticelist', (req, res) => {
+  db.query(`select title, href, end_date as enddate from notice_lists;`,
+    (error, result) => {
+      if (error) throw error;
+      console.log(result);
+      res.json(result);
+    })
+})
+
 module.exports = router;

--- a/back/routes/json.js
+++ b/back/routes/json.js
@@ -88,7 +88,7 @@ const hasKey = (arr, key, value) => {
 }
 
 router.get('/yearlycalendar', (req, res) => {
-  db.query(`select substring(link, 2) as 'idName', programs.title as title, gisus.gisu, visible, steps_calendars.title as stepTitle, detail, start_date as startDate, end_date as endDate from steps_calendars inner join gisus on steps_calendars.gisus_id = gisus.id inner join programs on gisus.programs_id = programs.id;`,
+  db.query(`select steps_calendars.id, substring(link, 2) as 'idName', programs.title as title, gisus.gisu, visible, steps_calendars.title as stepTitle, detail, start_date as startDate, end_date as endDate from steps_calendars inner join gisus on steps_calendars.gisus_id = gisus.id inner join programs on gisus.programs_id = programs.id;`,
     (error, result) => {
       if (error) throw error;
       let outerArr = [];
@@ -118,8 +118,9 @@ router.get('/yearlycalendar', (req, res) => {
         let innerArr = middleArr[middleArr.length - 1].step;
         //제일 바깥 어레이속 마지막 오브젝트의 step과 현재 v의 step이 같은지 체크
         //없으면 새로운 오브젝트 생성, 있으면 패스
-        if (!hasKey(innerArr, 'title', v.stepTitle)){
+        if (!hasKey(innerArr, 'id', v.id)){
           let obj3 = {
+            'id': v.id,
             'title': v.stepTitle,
             'period': v.detail,
             'startDate': v.startDate,
@@ -131,6 +132,7 @@ router.get('/yearlycalendar', (req, res) => {
       })
       // console.log(outerArr);
       res.send(outerArr);
+      // res.send(result);
   })
 })
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55867479/90333815-d289ee80-e003-11ea-8582-79638dbd2eaf.png)
'yearlycalendar' json을 보낼때 2기와 3기에서 1차 라피신은 잘 뜨는데 2차 라피신이 안뜨는 버그가 있었습니다.

원인을 알아보니 제가 내부 오브젝트를 만들때 subtitle(`라피신`, `지원`같은 값들)을 키로 쓰고 있었는데 라피신이 중복되는경우 그 다음 키값을 무시하게 만들었었습니다. 
중복되지 않는 값이 필요해서 db에 있는 ID를 키값으로 사용해서 해결했습니다.
![image](https://user-images.githubusercontent.com/55867479/90333845-17158a00-e004-11ea-9600-b1c9c108073e.png)
그 전과는 달리 id값도 출력되지만 이는 대리님 코드에서 무시되기 때문에 문제가 안될것으로 생각됩니다.
```javascript
if (!hasKey(innerArr, 'id', v.id)){
          let obj3 = {
            'id': v.id,
            'title': v.stepTitle,
            'period': v.detail,
            'startDate': v.startDate,
            'endDate': v.endDate,
          }
          if (!(v.visible >= 2 && v.stepTitle == '지원'))
           innerArr.push(obj3);
        }
```
json.js에서 yearlycalendar 라우터에서 위부분으로 수정했습니다.
navlist와 noticelist는 제가 예전에 만들었던 코드인데 이미 성상님께 반영되어 있어서 머지할때 버릴 부분이라 무시하셔도 됩니다.

#### 확인하는법
1. back폴더로 들어가서 `node bin/www` 명령어를 칩니다.
2. 브라우져에서 `localhost:5000/api/json/yearlycalendar`로 접속합니다.
3. yearlycalendar 컴포넌트에 있는 더미데이터와 위 주소에서 나오는 json파일이 서로 같은지 체크합니다.
4. 특히 42서울에서 2기 2차와 3기 2차가 제대로 있는지 확인하면 됩니다.