### PR TITLE
modify database date

### DIFF
--- a/front/components/TimelineListItem.js
+++ b/front/components/TimelineListItem.js
@@ -23,7 +23,7 @@ export default function TimelineListItem({data, id}) {
   }
 
   {/*
-  yebalja.com에서 불러오는 UTC시간에서 9시간을 빼주 KST로 바꿔줍니다.
+  yebalja.com에서 불러오는 UTC시간에서 9시간을 빼줘 KST로 바꿔줍니다.
   타임존 변경이 아닌 강제 시간 변경입니다.
   **예시**
   1. dataGrip에서 6월 6일 11시 입력
@@ -40,11 +40,8 @@ export default function TimelineListItem({data, id}) {
     4-2. localhost:3000에서 6월 6일 2시로 출력
 
   */}
-  console.log('data.startdate',data.startdate);
   let startdate_KST = new Date(new Date(data.startdate).getTime() - 540*60*1000);
   let enddate_KST = new Date(new Date(data.enddate).getTime() - 540*60*1000);
-
-  console.log('startdate_KST',startdate_KST);
 
   {/* 시작일, 마감일, 시작시간, 마감시간 구하기 */}
   let startdate = `${new Date(startdate_KST).getMonth() + 1}.${new Date(startdate_KST).getDate()}`;

--- a/front/components/TimelineListItem.js
+++ b/front/components/TimelineListItem.js
@@ -22,41 +22,58 @@ export default function TimelineListItem({data, id}) {
     updown = `down_${type}`;
   }
 
+  {/*
+  yebalja.com에서 불러오는 UTC시간에서 9시간을 더해주 KST로 바꿔줍니다.
+  타임존 변경이 아닌 강제 시간 변경입니다.
+  **예시**
+  1. dataGrip에서 6월 6일 11시 입력
+  2. localhost:5000/api/json/timelinelist에서 2020-06-06T02:00:00.000Z로 입력된 것을 확인
+    2-1. localhost:3000에서 6월 6일 11시로 출력
+  3. api.yebalja.com/api/json/timelinelist에서 2020-06-06T11:00:00.000Z로 입력된 것을 확인
+    3-1. yebalja.com에서 6월 6일 2시로 출력
+  4. 불러온 데이타의 시간에 강제로 +9시간 해서 2시를 11시로 출력하게 만듦
+    4-1. yebalja.com에서 6월 6일 11시로 출력
+    4-2. localhost:3000에서 6월 6일 20시로 출력
+
+  */}
+  let startdate_SKT = new Date(new Date(data.startdate).getTime() - 540*60*1000);
+  let enddate_SKT = new Date(new Date(data.enddate).getTime() - 540*60*1000);
+
   {/* 시작일, 마감일, 시작시간, 마감시간 구하기 */}
-  let startdate = `${new Date(data.startdate).getMonth() + 1}.${new Date(data.startdate).getDate()}`;
-  if (new Date(data.startdate).getFullYear() != new Date().getFullYear()) {
-    startdate = `${new Date(data.startdate).getFullYear()}.${startdate}`;
+  let startdate = `${new Date(startdate_KST).getMonth() + 1}.${new Date(startdate_KST).getDate()}`;
+  if (new Date(startdate_KST).getFullYear() != new Date().getFullYear()) {
+    startdate = `${new Date(startdate_KST).getFullYear()}.${startdate}`;
   }
-  let enddate = `${new Date(data.enddate).getMonth() + 1}.${new Date(data.enddate).getDate()}`;
+  let enddate = `${new Date(enddate_KST).getMonth() + 1}.${new Date(enddate_KST).getDate()}`;
   let starttime;
   let endtime;
   {/* 00:00 형태로 시작시간과 마감시간 뽑아내기 */}
-  if (new Date(data.startdate).getMinutes() < '10') {
-    starttime = `${new Date(data.startdate).getHours()}:0${new Date(data.startdate).getMinutes()}`;
+  if (new Date(startdate_KST).getMinutes() < '10') {
+    starttime = `${new Date(startdate_KST).getHours()}:0${new Date(startdate_KST).getMinutes()}`;
   } else {
-    starttime = `${new Date(data.startdate).getHours()}:${new Date(data.startdate).getMinutes()}`;
+    starttime = `${new Date(startdate_KST).getHours()}:${new Date(startdate_KST).getMinutes()}`;
   }
-  if (new Date(data.enddate).getMinutes() < '10') {
-    endtime = `${new Date(data.enddate).getHours()}:0${new Date(data.enddate).getMinutes()}`;
+  if (new Date(enddate_KST).getMinutes() < '10') {
+    endtime = `${new Date(enddate_KST).getHours()}:0${new Date(enddate_KST).getMinutes()}`;
   } else {
-    endtime = `${new Date(data.enddate).getHours()}:${new Date(data.enddate).getMinutes()}`;
+    endtime = `${new Date(enddate_KST).getHours()}:${new Date(enddate_KST).getMinutes()}`;
   }
 
 
   {/* 시작날까지 남은 날 && 마감날까지 남은 날 && 시작시간까지 남은 시간 && 마감시간까지 남은 시간 */}
-  let startdateLeft = Math.floor((new Date(data.startdate).setHours(0, 0, 0) - new Date().setHours(0)) / (1000 * 60 * 60 * 24)) + 1;
-  let enddateLeft = Math.floor((new Date(data.enddate).setHours(0, 0, 0) - new Date().setHours(0)) / (1000 * 60 * 60 * 24)) + 1;
+  let startdateLeft = Math.floor((new Date(startdate_KST).setHours(0, 0, 0) - new Date().setHours(0)) / (1000 * 60 * 60 * 24)) + 1;
+  let enddateLeft = Math.floor((new Date(enddate_KST).setHours(0, 0, 0) - new Date().setHours(0)) / (1000 * 60 * 60 * 24)) + 1;
   let starttimeLeft;
   let endtimeLeft;
   if (starttime == '0:00') {
-    starttimeLeft = Math.floor((new Date(data.startdate).setHours(23,59,59) - new Date()) / (1000)) + 1;
+    starttimeLeft = Math.floor((new Date(startdate_KST).setHours(23,59,59) - new Date()) / (1000)) + 1;
   } else {
-    starttimeLeft = Math.floor((new Date(data.startdate) - new Date()) / (1000)) + 1;
+    starttimeLeft = Math.floor((new Date(startdate_KST) - new Date()) / (1000)) + 1;
   }
   if (endtime == '0:00') {
-    endtimeLeft = Math.floor((new Date(data.enddate).setHours(23,59,59) - new Date()) / (1000)) + 1;
+    endtimeLeft = Math.floor((new Date(enddate_KST).setHours(23,59,59) - new Date()) / (1000)) + 1;
   } else {
-    endtimeLeft = Math.floor((new Date(data.enddate) - new Date()) / (1000)) + 1;
+    endtimeLeft = Math.floor((new Date(enddate_KST) - new Date()) / (1000)) + 1;
   }
 
 

--- a/front/components/TimelineListItem.js
+++ b/front/components/TimelineListItem.js
@@ -23,21 +23,28 @@ export default function TimelineListItem({data, id}) {
   }
 
   {/*
-  yebalja.com에서 불러오는 UTC시간에서 9시간을 더해주 KST로 바꿔줍니다.
+  yebalja.com에서 불러오는 UTC시간에서 9시간을 빼주 KST로 바꿔줍니다.
   타임존 변경이 아닌 강제 시간 변경입니다.
   **예시**
   1. dataGrip에서 6월 6일 11시 입력
-  2. localhost:5000/api/json/timelinelist에서 2020-06-06T02:00:00.000Z로 입력된 것을 확인
-    2-1. localhost:3000에서 6월 6일 11시로 출력
-  3. api.yebalja.com/api/json/timelinelist에서 2020-06-06T11:00:00.000Z로 입력된 것을 확인
-    3-1. yebalja.com에서 6월 6일 2시로 출력
-  4. 불러온 데이타의 시간에 강제로 +9시간 해서 2시를 11시로 출력하게 만듦
+  2. api.yebalja.com/api/json/timelinelist에서 2020-06-06T11:00:00.000Z로 입력된 것을 확인
+    2-1. yebalja.com에서 6월 6일 20시로 출력
+    2-2. 11:00:00 UTC로 인식
+    2-3. 20:00:00 GMT+9:00라 20시
+  3. localhost:5000/api/json/timelinelist에서 2020-06-06T02:00:00.000Z로 입력된 것을 확인
+    3-1. localhost:3000에서 6월 6일 11시로 출력
+    3-2. 02:00:00 UTC로 인식
+    3-3. 11:00:00 GMT+9:00라 11시
+  4. 불러온 데이타의 시간에 강제로 -9시간 해서 2시를 11시로 출력하게 만듦
     4-1. yebalja.com에서 6월 6일 11시로 출력
-    4-2. localhost:3000에서 6월 6일 20시로 출력
+    4-2. localhost:3000에서 6월 6일 2시로 출력
 
   */}
-  let startdate_SKT = new Date(new Date(data.startdate).getTime() - 540*60*1000);
-  let enddate_SKT = new Date(new Date(data.enddate).getTime() - 540*60*1000);
+  console.log('data.startdate',data.startdate);
+  let startdate_KST = new Date(new Date(data.startdate).getTime() - 540*60*1000);
+  let enddate_KST = new Date(new Date(data.enddate).getTime() - 540*60*1000);
+
+  console.log('startdate_KST',startdate_KST);
 
   {/* 시작일, 마감일, 시작시간, 마감시간 구하기 */}
   let startdate = `${new Date(startdate_KST).getMonth() + 1}.${new Date(startdate_KST).getDate()}`;


### PR DESCRIPTION
### :clock11: yebalja.com에서 불러오는 UTC시간에서 9시간을 빼줍니다
#### 타임존 변경이 아닌 강제 시간 변경입니다.
- 데이타베이스에서 불러오는 시간 데이타 대신 이제는 새로운 변수를 입력합니다
  `data.stardate` >> `startdate_KST`
  `data.enddate` >> `enddate_KST`
- `startdate_KST`와 `enddate_KST`는 데이타베이스에서 불러온 시간에서 9시간을 빼준 시간입니다.

#### 미혜님 댓글에 달아둔 설명 읽으시면 더 이해가 잘 되실 것 같습니다

  :memo: **예시**
  1. dataGrip에서 ssafy 1차 온라인 적성진단 stardate에 **6월 6일 11시 입력**
  2. api.yebalja.com/api/json/timelinelist에서 2020-06-06T11:00:00.000Z로 입력된 것을 확인
    2-1. **yebalja.com에서 6월 6일 20시로 출력** :exclamation: 에러발생
    2-2. 11:00:00 UTC로 인식
    2-3. 20:00:00 GMT+9:00라 20시
  3. localhost:5000/api/json/timelinelist에서 2020-06-06T02:00:00.000Z로 입력된 것을 확인
    3-1. **localhost:3000에서 6월 6일 11시로 출력** :+1: 
    3-2. 02:00:00 UTC로 인식
    3-3. 11:00:00 GMT+9:00라 11시
  4. 불러온 데이타의 시간에 강제로 -9시간 해서 2시를 11시로 출력하게 만듦
    4-1. **yebalja.com에서 6월 6일 11시로 출력** :+1: 이제 잘 작동
    4-2. **localhost:3000에서 6월 6일 2시로 출력** :exclamation: 안되지만 어쩔 수 없는..

#### localhost:3000에서는 시간이 제대로 나오지 않습니다. yebalja.com에서만 제대로 나오게 코드를 바꿨습니다.
localhost와 yebalja.com의 시간이 다른 부분은 이유를 모르겠어서 일단 급한 것부터 해결했습니다.

#### localhost:3000/ssafy 시간들이 아래와 같으면 아마 성공
<p align="center"><img src="https://user-images.githubusercontent.com/52592748/91153900-c97fd800-e6fb-11ea-99d3-f2ef04437435.png" width="350"></p>

